### PR TITLE
Add Xquik MCP entry and harden OAuth redirects

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,11 +1,12 @@
 import { ensureUserExists } from "@/actions/user";
+import { getSafeRedirectPath } from "@/lib/auth-redirect";
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/";
+  const next = getSafeRedirectPath(searchParams.get("next"));
 
   if (code) {
     const supabase = await createClient();
@@ -21,16 +22,9 @@ export async function GET(request: Request) {
 
       const forwardedHost = request.headers.get("x-forwarded-host");
       const isLocalEnv = process.env.NODE_ENV === "development";
+      const redirectOrigin = isLocalEnv || !forwardedHost ? origin : `https://${forwardedHost}`;
 
-      if (isLocalEnv) {
-        return NextResponse.redirect(`${origin}${next}`);
-      }
-
-      if (forwardedHost) {
-        return NextResponse.redirect(`https://${forwardedHost}${next}`);
-      }
-
-      return NextResponse.redirect(`${origin}${next}`);
+      return NextResponse.redirect(new URL(next, redirectOrigin));
     }
 
     const msg = error?.message || "unknown_exchange_error";

--- a/src/components/github-signin.tsx
+++ b/src/components/github-signin.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { createAuthCallbackUrl } from "@/lib/auth-redirect";
 import { createClient } from "@/utils/supabase/client";
 import { useSearchParams } from "next/navigation";
 import { FaGithub } from "react-icons/fa";
@@ -18,7 +19,7 @@ export function GithubSignin() {
         supabase.auth.signInWithOAuth({
           provider: "github",
           options: {
-            redirectTo: `${window.location.origin}/auth/callback?next=${next}`,
+            redirectTo: createAuthCallbackUrl(window.location.origin, next),
           },
         });
       }}

--- a/src/components/google-signin.tsx
+++ b/src/components/google-signin.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { createAuthCallbackUrl } from "@/lib/auth-redirect";
 import { createClient } from "@/utils/supabase/client";
 import { useSearchParams } from "next/navigation";
 import { FcGoogle } from "react-icons/fc";
@@ -18,7 +19,7 @@ export function GoogleSignin() {
         supabase.auth.signInWithOAuth({
           provider: "google",
           options: {
-            redirectTo: `${window.location.origin}/auth/callback?next=${next}`,
+            redirectTo: createAuthCallbackUrl(window.location.origin, next),
           },
         });
       }}

--- a/src/data/mcp/index.ts
+++ b/src/data/mcp/index.ts
@@ -82,6 +82,12 @@ export default [
     logo: "https://cdn.brandfetch.io/idJ_HhtG0Z/theme/dark/symbol.svg?c=1dxbfHSJFAPEGdCLU4o5B",
   },
   {
+    name: "Xquik",
+    url: "https://github.com/Xquik-dev/x-twitter-scraper",
+    description:
+      "X data platform with REST endpoints, MCP tools, webhooks, SDKs, and confirmed writes.",
+  },
+  {
     name: "Cloudflare",
     url: "https://github.com/cloudflare/mcp-server-cloudflare",
     description: "Deploy and manage resources on the Cloudflare developer platform",

--- a/src/lib/auth-redirect.test.ts
+++ b/src/lib/auth-redirect.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { createAuthCallbackUrl, getSafeRedirectPath } from "./auth-redirect";
+
+describe("getSafeRedirectPath", () => {
+  test("preserves a local path with query and fragment", () => {
+    assert.equal(
+      getSafeRedirectPath("/g/example?tab=one&view=full#result"),
+      "/g/example?tab=one&view=full#result",
+    );
+  });
+
+  for (const value of [
+    "https://attacker.example",
+    "//attacker.example",
+    "@attacker.example",
+    ".attacker.example",
+  ]) {
+    test(`rejects external redirect value ${value}`, () => {
+      assert.equal(getSafeRedirectPath(value), "/");
+    });
+  }
+
+  test("rejects a backslash authority redirect", () => {
+    assert.equal(getSafeRedirectPath("/\\attacker.example"), "/");
+  });
+});
+
+describe("createAuthCallbackUrl", () => {
+  test("encodes the full local destination in one query parameter", () => {
+    const callbackUrl = new URL(
+      createAuthCallbackUrl("https://sub-agents.directory", "/g/example?tab=one&view=full#result"),
+    );
+
+    assert.equal(callbackUrl.origin, "https://sub-agents.directory");
+    assert.equal(callbackUrl.pathname, "/auth/callback");
+    assert.equal(callbackUrl.searchParams.get("next"), "/g/example?tab=one&view=full#result");
+  });
+});

--- a/src/lib/auth-redirect.ts
+++ b/src/lib/auth-redirect.ts
@@ -1,0 +1,24 @@
+const SAFE_ORIGIN = "https://local.invalid";
+
+export function getSafeRedirectPath(value: string | null | undefined): string {
+  if (!value || !value.startsWith("/")) {
+    return "/";
+  }
+
+  try {
+    const parsed = new URL(value, SAFE_ORIGIN);
+    if (parsed.origin !== SAFE_ORIGIN) {
+      return "/";
+    }
+
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return "/";
+  }
+}
+
+export function createAuthCallbackUrl(origin: string, next: string | null | undefined): string {
+  const callbackUrl = new URL("/auth/callback", origin);
+  callbackUrl.searchParams.set("next", getSafeRedirectPath(next));
+  return callbackUrl.toString();
+}


### PR DESCRIPTION
## Summary
- Add Xquik to the MCP server directory with count-neutral metadata.
- Address Greptile review feedback about endpoint count accuracy.
- Harden OAuth return redirects against external authorities while preserving local query strings and fragments.
- Encode OAuth callback destinations as one query parameter.

The OAuth redirect hardening is an independent repository fix.

## Validation
- `bun test src/lib/auth-redirect.test.ts` (7 passed)
- `bun run generate:rules` (154 rules generated)
- `bun run typecheck`
- `bun run lint` (passes with 1 existing no-console warning)
- focused `oxfmt --check` on all changed TypeScript files
- `git diff --check upstream/main...HEAD`

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.