### PR TITLE
move runtime database access from Prisma to Supabase REST

### DIFF
--- a/src/actions/save-generation.ts
+++ b/src/actions/save-generation.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { ensureUserExists } from "@/actions/user";
-import { getPrisma } from "@/lib/prisma";
+import { supabaseAdmin, supabaseRead } from "@/lib/supabase-rest";
 import { createClient } from "@/utils/supabase/server";
 import { customAlphabet } from "nanoid";
 
@@ -21,33 +21,51 @@ export async function saveGeneration(input: string, content: string) {
 
   const slug = nanoid();
 
-  const generation = await getPrisma().generation.create({
-    data: {
+  const { data: generation, error } = await supabaseAdmin()
+    .from("generations")
+    .insert({
       slug,
-      userId: user.id,
+      user_id: user.id,
       input,
       content,
-    },
-  });
+    })
+    .select("id, slug")
+    .single();
+
+  if (error) {
+    throw error;
+  }
 
   return {
-    slug: generation.slug,
-    id: generation.id,
+    slug: generation.slug as string,
+    id: generation.id as string,
   };
 }
 
 export async function getGenerationBySlug(slug: string) {
-  return getPrisma().generation.findUnique({
-    where: { slug },
-    include: {
-      user: {
-        select: {
-          id: true,
-          name: true,
-          username: true,
-          avatarUrl: true,
-        },
-      },
+  const { data } = await supabaseRead()
+    .from("generations")
+    .select("id, slug, content, title, created_at, user:users(id, name, username, avatar_url)")
+    .eq("slug", slug)
+    .maybeSingle();
+
+  if (!data) {
+    return null;
+  }
+
+  const u = Array.isArray(data.user) ? data.user[0] : data.user;
+
+  return {
+    id: data.id as string,
+    slug: data.slug as string,
+    content: data.content as string,
+    title: (data.title as string | null) ?? null,
+    createdAt: new Date(data.created_at as string),
+    user: {
+      id: u?.id as string,
+      name: (u?.name as string | null) ?? null,
+      username: u?.username as string,
+      avatarUrl: (u?.avatar_url as string | null) ?? null,
     },
-  });
+  };
 }

--- a/src/actions/user.ts
+++ b/src/actions/user.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { getPrisma } from "@/lib/prisma";
+import { supabaseAdmin, supabaseRead } from "@/lib/supabase-rest";
 import { createClient } from "@/utils/supabase/server";
 
 function generateUsername(email: string | undefined, name: string | undefined): string {
@@ -31,9 +31,9 @@ export async function ensureUserExists() {
     return null;
   }
 
-  const existingUser = await getPrisma().user.findUnique({
-    where: { id: user.id },
-  });
+  const db = supabaseAdmin();
+
+  const { data: existingUser } = await db.from("users").select("*").eq("id", user.id).maybeSingle();
 
   if (existingUser) {
     return existingUser;
@@ -44,54 +44,73 @@ export async function ensureUserExists() {
   const name = metadata.full_name || metadata.name || user.email?.split("@")[0];
   let username = githubUsername || generateUsername(user.email ?? undefined, name);
 
-  const existingUsername = await getPrisma().user.findUnique({
-    where: { username },
-  });
+  const { data: existingUsername } = await db
+    .from("users")
+    .select("id")
+    .eq("username", username)
+    .maybeSingle();
 
   if (existingUsername) {
     username = `${username}-${Date.now().toString(36).slice(-4)}`;
   }
 
-  const newUser = await getPrisma().user.create({
-    data: {
+  const { data: newUser, error } = await db
+    .from("users")
+    .insert({
       id: user.id,
-      email: user.email,
+      email: user.email ?? null,
       name: name || null,
       username,
-      avatarUrl: metadata.avatar_url || null,
-    },
-  });
+      avatar_url: metadata.avatar_url || null,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw error;
+  }
 
   return newUser;
 }
 
 export async function getUserByUsername(username: string) {
-  return getPrisma().user.findUnique({
-    where: { username },
-    include: {
-      _count: {
-        select: { generations: true },
-      },
-    },
-  });
+  const { data } = await supabaseRead()
+    .from("users")
+    .select("id, username, name, avatar_url, generations(count)")
+    .eq("username", username)
+    .maybeSingle();
+
+  if (!data) {
+    return null;
+  }
+
+  return {
+    id: data.id as string,
+    username: data.username as string,
+    name: (data.name as string | null) ?? null,
+    avatarUrl: (data.avatar_url as string | null) ?? null,
+    _count: { generations: data.generations?.[0]?.count ?? 0 },
+  };
 }
 
 export async function getMembers(page = 1, limit = 24) {
   const skip = (page - 1) * limit;
 
-  const [members, total] = await Promise.all([
-    getPrisma().user.findMany({
-      include: {
-        _count: {
-          select: { generations: true },
-        },
-      },
-      orderBy: { createdAt: "desc" },
-      skip,
-      take: limit,
-    }),
-    getPrisma().user.count(),
-  ]);
+  const { data, count } = await supabaseRead()
+    .from("users")
+    .select("id, username, name, avatar_url, generations(count)", { count: "exact" })
+    .order("created_at", { ascending: false })
+    .range(skip, skip + limit - 1);
+
+  const members = (data ?? []).map((u) => ({
+    id: u.id as string,
+    username: u.username as string,
+    name: (u.name as string | null) ?? null,
+    avatarUrl: (u.avatar_url as string | null) ?? null,
+    _count: { generations: u.generations?.[0]?.count ?? 0 },
+  }));
+
+  const total = count ?? 0;
 
   return {
     members,
@@ -103,17 +122,22 @@ export async function getMembers(page = 1, limit = 24) {
 export async function getUserGenerations(userId: string, page = 1, limit = 12) {
   const skip = (page - 1) * limit;
 
-  const [generations, total] = await Promise.all([
-    getPrisma().generation.findMany({
-      where: { userId },
-      orderBy: { createdAt: "desc" },
-      skip,
-      take: limit,
-    }),
-    getPrisma().generation.count({
-      where: { userId },
-    }),
-  ]);
+  const { data, count } = await supabaseRead()
+    .from("generations")
+    .select("id, slug, content, title, created_at", { count: "exact" })
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false })
+    .range(skip, skip + limit - 1);
+
+  const generations = (data ?? []).map((g) => ({
+    id: g.id as string,
+    slug: g.slug as string,
+    content: g.content as string,
+    title: (g.title as string | null) ?? null,
+    createdAt: new Date(g.created_at as string),
+  }));
+
+  const total = count ?? 0;
 
   return {
     generations,

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -12,7 +12,12 @@ export async function GET(request: Request) {
     const { error, data } = await supabase.auth.exchangeCodeForSession(code);
 
     if (!error && data?.user) {
-      await ensureUserExists();
+      // Best-effort: a failed user-record upsert must not block authentication.
+      try {
+        await ensureUserExists();
+      } catch (e) {
+        console.error("ensureUserExists failed during auth callback", e);
+      }
 
       const forwardedHost = request.headers.get("x-forwarded-host");
       const isLocalEnv = process.env.NODE_ENV === "development";

--- a/src/app/debug/page.tsx
+++ b/src/app/debug/page.tsx
@@ -1,5 +1,5 @@
 import { createClient } from "@/utils/supabase/server";
-import { getPrisma } from "@/lib/prisma";
+import { supabaseAdmin } from "@/lib/supabase-rest";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -22,10 +22,12 @@ export default async function DebugPage() {
 
   let dbUser = null;
   if (user) {
-    dbUser = await getPrisma().user.findUnique({
-      where: { id: user.id },
-      include: { _count: { select: { generations: true, rateLimits: true } } },
-    });
+    const { data } = await supabaseAdmin()
+      .from("users")
+      .select("*, generations(count), generate_rate_limits(count)")
+      .eq("id", user.id)
+      .maybeSingle();
+    dbUser = data;
   }
 
   return (

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,8 +1,0 @@
-import { PrismaClient } from "@/generated/prisma/client";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { cache } from "react";
-
-export const getPrisma = cache(() => {
-  const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
-  return new PrismaClient({ adapter });
-});

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,4 +1,4 @@
-import { getPrisma } from "@/lib/prisma";
+import { supabaseAdmin } from "@/lib/supabase-rest";
 
 const RATE_LIMIT_WINDOW_MS = 60 * 1000;
 const MAX_REQUESTS_PER_WINDOW = 5;
@@ -21,33 +21,33 @@ interface RateLimitResult {
 
 export async function checkRateLimit(userId: string): Promise<RateLimitResult> {
   const now = Date.now();
-  const windowStart = new Date(now - RATE_LIMIT_WINDOW_MS);
+  const windowStart = new Date(now - RATE_LIMIT_WINDOW_MS).toISOString();
 
-  const requests = await getPrisma().generateRateLimit.findMany({
-    where: {
-      userId,
-      createdAt: { gte: windowStart },
-    },
-    orderBy: { createdAt: "desc" },
-  });
+  const db = supabaseAdmin();
 
-  const requestCount = requests.length;
+  const { data: requests } = await db
+    .from("generate_rate_limits")
+    .select("created_at")
+    .eq("user_id", userId)
+    .gte("created_at", windowStart)
+    .order("created_at", { ascending: false });
+
+  const rows = requests ?? [];
+  const requestCount = rows.length;
   const remaining = Math.max(0, MAX_REQUESTS_PER_WINDOW - requestCount);
 
   if (requestCount >= MAX_REQUESTS_PER_WINDOW) {
-    const oldestRequest = requests[requests.length - 1];
+    const oldestRequest = rows[rows.length - 1];
     const resetTime = oldestRequest
-      ? oldestRequest.createdAt.getTime() + RATE_LIMIT_WINDOW_MS
+      ? new Date(oldestRequest.created_at as string).getTime() + RATE_LIMIT_WINDOW_MS
       : now + RATE_LIMIT_WINDOW_MS;
 
     return { success: false, reset: resetTime, remaining: 0 };
   }
 
-  await getPrisma().generateRateLimit.create({
-    data: {
-      userId,
-      createdAt: new Date(now),
-    },
+  await db.from("generate_rate_limits").insert({
+    user_id: userId,
+    created_at: new Date(now).toISOString(),
   });
 
   return { success: true, reset: now + RATE_LIMIT_WINDOW_MS, remaining: remaining - 1 };

--- a/src/lib/supabase-rest.ts
+++ b/src/lib/supabase-rest.ts
@@ -1,0 +1,25 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+
+const options = {
+  auth: { persistSession: false, autoRefreshToken: false },
+} as const;
+
+// Anon-key client for reading public data (members, profiles, generations).
+// Runs over HTTP fetch, so it works on the Cloudflare Workers runtime where
+// Prisma's wasm query engine cannot (Workers disallow runtime wasm compilation).
+export function supabaseRead(): SupabaseClient {
+  return createClient(url, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, options);
+}
+
+// Service-role client for privileged server-side writes (user/generation
+// creation, rate limiting). Bypasses RLS, matching the old direct-Postgres
+// access. Never import this into client components.
+export function supabaseAdmin(): SupabaseClient {
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!key) {
+    throw new Error("SUPABASE_SERVICE_ROLE_KEY is not set");
+  }
+  return createClient(url, key, options);
+}


### PR DESCRIPTION
## Problem

`/members` (and every dynamic DB route) returned 500 in production. Root cause: the site runs on **Cloudflare Workers** via OpenNext, and **Prisma 7 cannot run there** — its query engine compiles wasm at runtime, which Workers forbid (`CompileError: Wasm code generation disallowed by embedder`). `pg`/node-postgres had a separate Workers bundling failure on top. This is why the app had been pushed fully static.

## Fix

Move runtime DB access off Prisma onto fetch-based **Supabase REST**, which works natively on Workers (`src/lib/supabase-rest.ts`):

- `supabaseRead()` (anon key) — public reads: members, profiles, generations
- `supabaseAdmin()` (service role key) — privileged writes: user creation on login, generation save, rate limit

Prisma is kept only for schema/migrations; auth still uses Supabase. The auth callback now creates the user record best-effort so a failed write never blocks login.

## Result

- `/members` and `/u/[slug]` profiles return 200 (verified live)
- Worker bundle: **4.45 MiB → 2.83 MiB**, zero Prisma wasm and zero `pg` at runtime
- New Worker secret required: `SUPABASE_SERVICE_ROLE_KEY` (already set). `DATABASE_URL` secret is now unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
