### PR TITLE
address greptile review on the supabase migration

### DIFF
--- a/src/app/debug/page.tsx
+++ b/src/app/debug/page.tsx
@@ -101,7 +101,7 @@ export default async function DebugPage() {
       </section>
 
       <section className="mb-8">
-        <h2 className="text-lg font-semibold mb-2">Database User (Prisma)</h2>
+        <h2 className="text-lg font-semibold mb-2">Database User (Supabase)</h2>
         {dbUser ? (
           <pre className="bg-muted p-4 rounded text-xs overflow-auto">
             {JSON.stringify(dbUser, null, 2)}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -25,12 +25,18 @@ export async function checkRateLimit(userId: string): Promise<RateLimitResult> {
 
   const db = supabaseAdmin();
 
-  const { data: requests } = await db
+  const { data: requests, error: selectError } = await db
     .from("generate_rate_limits")
     .select("created_at")
     .eq("user_id", userId)
     .gte("created_at", windowStart)
     .order("created_at", { ascending: false });
+
+  // Fail closed: a DB read error must not be treated as "no requests yet",
+  // which would let the caller bypass the limit.
+  if (selectError) {
+    throw selectError;
+  }
 
   const rows = requests ?? [];
   const requestCount = rows.length;
@@ -45,10 +51,17 @@ export async function checkRateLimit(userId: string): Promise<RateLimitResult> {
     return { success: false, reset: resetTime, remaining: 0 };
   }
 
-  await db.from("generate_rate_limits").insert({
+  // The Supabase JS client returns { error } instead of throwing. If the
+  // attempt cannot be recorded, fail closed rather than silently granting it,
+  // otherwise a flaky write lets the user exceed MAX_REQUESTS_PER_WINDOW.
+  const { error: insertError } = await db.from("generate_rate_limits").insert({
     user_id: userId,
     created_at: new Date(now).toISOString(),
   });
+
+  if (insertError) {
+    throw insertError;
+  }
 
   return { success: true, reset: now + RATE_LIMIT_WINDOW_MS, remaining: remaining - 1 };
 }

--- a/src/lib/supabase-rest.ts
+++ b/src/lib/supabase-rest.ts
@@ -1,25 +1,35 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-
 const options = {
   auth: { persistSession: false, autoRefreshToken: false },
 } as const;
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is not set`);
+  }
+  return value;
+}
 
 // Anon-key client for reading public data (members, profiles, generations).
 // Runs over HTTP fetch, so it works on the Cloudflare Workers runtime where
 // Prisma's wasm query engine cannot (Workers disallow runtime wasm compilation).
 export function supabaseRead(): SupabaseClient {
-  return createClient(url, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, options);
+  return createClient(
+    requireEnv("NEXT_PUBLIC_SUPABASE_URL"),
+    requireEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY"),
+    options,
+  );
 }
 
 // Service-role client for privileged server-side writes (user/generation
 // creation, rate limiting). Bypasses RLS, matching the old direct-Postgres
 // access. Never import this into client components.
 export function supabaseAdmin(): SupabaseClient {
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!key) {
-    throw new Error("SUPABASE_SERVICE_ROLE_KEY is not set");
-  }
-  return createClient(url, key, options);
+  return createClient(
+    requireEnv("NEXT_PUBLIC_SUPABASE_URL"),
+    requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
+    options,
+  );
 }


### PR DESCRIPTION
Addresses the Greptile review on #8.

- **rate-limit (P1)**: the Supabase JS client returns `{ error }` rather than throwing, so the unchecked insert could return `success: true` on a failed write, letting a user exceed the limit. Now checks both the select and insert error results and fails closed (matching the old Prisma throw-on-error behavior).
- **supabase-rest (P2)**: replaced the `!` non-null assertions on `NEXT_PUBLIC_SUPABASE_URL` / keys with a `requireEnv` guard that throws a clear "X is not set" message, consistent with `supabaseAdmin`'s existing key check.
- **debug (P2)**: updated the stale "Database User (Prisma)" heading to "Database User (Supabase)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
