### PR TITLE
Add AgentServices — x402-paid data APIs with 37 MCP tools

### DIFF
--- a/src/data/mcp/index.ts
+++ b/src/data/mcp/index.ts
@@ -112,4 +112,10 @@ export default [
       "This server provides integration with Github's issue tracking system through MCP, allowing LLMs to interact with Github issues.",
     logo: "https://cdn.brandfetch.io/idZAyF9rlg/theme/light/symbol.svg?c=1dxbfHSJFAPEGdCLU4o5B",
   },
+  {
+    name: "AgentServices",
+    url: "https://agentservices.to",
+    description:
+      "Paid data APIs for AI agents with x402 payments. 54 services, 97 endpoints, 41 x402-paid endpoints, and 37 MCP tools for market data, financial intelligence, and onchain analytics.",
+  },
 ];


### PR DESCRIPTION
## What is AgentServices?

AgentServices ([agentservices.to](https://agentservices.to)) provides paid data APIs for AI agents with x402 payments and MCP access.

- **54 services** across market data, financial intelligence, and onchain analytics
- **97 API endpoints** (41 x402-paid)
- **37 MCP tools** available via MCP server
- **x402 payment protocol** — agents pay per-call with USDC on Base

### MCP Server
- Registry: `to.agentservices/agentservices` (v5.3.0)
- Protocol: 2026-07-28

### Links
- Website: https://agentservices.to
- API docs: https://api.agentservices.to/docs
- MCP handshake: https://agentservices.to/mcp

Added as a new entry in `src/data/mcp/index.ts`.