### PR TITLE
Add Parallel Search to the MCP directory

### DIFF
--- a/src/data/mcp/index.ts
+++ b/src/data/mcp/index.ts
@@ -112,4 +112,10 @@ export default [
       "This server provides integration with Github's issue tracking system through MCP, allowing LLMs to interact with Github issues.",
     logo: "https://cdn.brandfetch.io/idZAyF9rlg/theme/light/symbol.svg?c=1dxbfHSJFAPEGdCLU4o5B",
   },
+  {
+    name: "Parallel Search",
+    url: "https://docs.parallel.ai/integrations/mcp/search-mcp",
+    description:
+      "An optional hosted search MCP at https://search.parallel.ai/mcp. Users must explicitly opt in before using it; user-provided search objectives, search queries, and requested URLs are sent to Parallel.",
+  },
 ];


### PR DESCRIPTION
## Summary

- add Parallel Search as an optional entry in the existing MCP directory
- link installation instructions to the official documentation and identify the hosted endpoint
- state that users must explicitly opt in and that user-provided search objectives, search queries, and requested URLs are sent to Parallel

## Validation

- verified the registry contains one entry with the required documentation URL, hosted endpoint, opt-in language, and data-sharing disclosure
- `git diff --check`

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.