### PR TITLE
Add Agent QA to the MCP server directory

### DIFF
--- a/src/data/mcp/index.ts
+++ b/src/data/mcp/index.ts
@@ -118,4 +118,10 @@ export default [
     description:
       "An optional hosted search MCP at https://search.parallel.ai/mcp. Users must explicitly opt in before using it; user-provided search objectives, search queries, and requested URLs are sent to Parallel.",
   },
+  {
+    name: "Agent QA",
+    url: "https://vostride.com/docs/agent-qa/mcp",
+    description:
+      "MCP tools for authoring and running natural-language web, Android, and iOS tests, inspecting artifacts, and triaging failures. Start stdio with agent-qa mcp; authoring and run tools require a running dashboard and dashboardUrl. Source-available (FSL-1.1-ALv2); model and infrastructure costs are separate.",
+  },
 ];


### PR DESCRIPTION
Adds Agent QA to the MCP server catalog, with a link to its [official installation and transport documentation](https://vostride.com/docs/agent-qa/mcp). It exposes application-test authoring, run, artifact, and failure-triage tools for natural-language web, Android, and iOS testing.

The entry includes the `agent-qa mcp` stdio command and the running-dashboard/`dashboardUrl` requirement for authoring and run tools. The CLI requires Node.js 24+; the linked documentation covers setup.

Agent QA is source-available under [FSL-1.1-ALv2](https://github.com/vostride/agent-qa/blob/main/LICENSE.md). There is no software charge for permitted uses; model, hosting, and device-provider costs are separate.

Validation: imported the actual TypeScript data module with Node 24 and checked required fields, unique names/URLs, and the 17 → 18 record change. All 17 previous records are identical. The new documentation link returns HTTP 200, and `git diff --check` passes. An earlier same-day smoke test of the published `agent-qa@0.1.21` stdio server discovered 33 tools and exercised local discovery/schema/ID validation; it did not run dashboard-backed tests, model providers, or a major assistant. This data-only contribution does not include a full Next.js build or browser run.

Disclosure: I am affiliated with Agent QA.
